### PR TITLE
Adds pyenv to testing

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -3,31 +3,78 @@
 # From the latest long-term support version of Ubuntu.
 FROM ubuntu:rolling
 
-# Install generic build dependencies.
-RUN apt-get update
-RUN apt-get install -y apt-utils build-essential curl git libssl-dev pandoc python3.6 python3-pip software-properties-common wget
+# Set noninteractive so that there are no interactive prompts during instalation.
+#   Using ARG ensures the environment variable is only present for build and not for execution.
+ARG DEBIAN_FRONTEND=noninteractive
 
-# Install Ethereum, Heroku CLI, MongoDB, NodeJS, Solidity.
-RUN wget -qO- https://cli-assets.heroku.com/install-ubuntu.sh | sh
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN add-apt-repository ppa:ethereum/ethereum
-RUN apt-get update
-RUN apt-get install -y ethereum mongodb-org nodejs solc
+# Install generic build dependencies and add repositories
+RUN apt-get update \
+ && apt-get install -y \
+      software-properties-common \
+      apt-transport-https \
+ && add-apt-repository ppa:ethereum/ethereum \
+ #  Mongodb release key and repository
+ && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 \
+ && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list \
+ #  Nodesource release key and repository
+ && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280 \
+ && DISTRO="$(lsb_release -s -c)" \
+ && NODE_VERSION="node_8.x" \
+ && echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list \
+ && echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list \
+ #  Heroku release key and repository
+ && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv 150C6249147592DE6D91981CC927EBE00F1B0520 \
+ && echo "deb https://cli-assets.heroku.com/apt ./" > /etc/apt/sources.list.d/heroku.list \
+ #  Clean up files to reduce image size
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install all required packages
+RUN apt-get update \ 
+ && apt-get install -y \
+      build-essential \
+      wget \
+      curl \
+      git \
+      pandoc \
+      heroku \
+      libssl-dev \
+      python3-pip \
+      python3-dev \
+      libbz2-dev \
+      libsqlite3-dev \
+      libreadline-dev \
+      ethereum \
+      mongodb-org \
+      nodejs \
+      solc \
+ #  Clean up files to reduce image size
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Installs pyenv to enable installation of several python versions
+ENV PATH="/root/.pyenv/bin:$PATH"
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+ && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile \
+ && echo 'export PATH="/root/.pyenv/bin:$PATH"' >> ~/.bash_profile \
+ && echo 'eval "\$(pyenv init -)"' >> ~/.bash_profile \
+ && echo 'eval "\$(pyenv virtualenv-init -)"' >> ~/.bash_profile \
+ && pip3 install tox-pyenv 
+
+# Install Pythons
+RUN pyenv install 3.4.8
+RUN pyenv install 3.5.5
+RUN pyenv install 3.6.5
+
+# Activate pythons
+WORKDIR home
+RUN pyenv global \
+      3.4.8 \
+      3.5.5 \
+      3.6.5
 
 # Install Truffle.
 RUN npm install -g truffle
-
-# Install Python dependencies of Mythril.
-RUN pip3 install --upgrade pip
-RUN pip3 install BTrees coverage eth_abi eth-account eth-hash eth-keyfile eth-keys eth-rlp eth-tester eth-utils ethereum plyvel py-flags py-solc requests setuptools twine z3-solver ZODB
-
-# Additional configuration.
-WORKDIR home
-RUN rm /usr/bin/python
-RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 # Copying-in auxiliary assets.
 COPY ethereum.password install-mythril-tools.sh ./


### PR DESCRIPTION
First of all, this should not change anything with the way the current tests are running. There should be no regressions from this change for the current pipeline.

This pull request adds pyenv and tox to the container so that the current tests can be run across several versions of python. Currently this is `3.4.8`, `3.5.5`, and `3.6.5`.

I added a build argument to specify the node version to be installed into the container. It defaults to the `8.x.x` channel, but can be overridden by using `docker build --build-arg NODE_VERSION="node_10.x".

I also cleaned up the build to create fewer intermediate images and hopefully keep the image size down.

In the future it might be worth waiting to do the geth sync until the container is run, and storing that result in the circle-ci cache. That would decrease the image size by a good amount.